### PR TITLE
diagnostic のパース処理にミスがあったので修正

### DIFF
--- a/tap.go
+++ b/tap.go
@@ -261,7 +261,7 @@ func (p *Parser) parseTestLine(ok bool, line string, indent string) (*Testline, 
 		text := p.scanner.Text()
 
 		// ignore indent
-		if !strings.HasPrefix(line, indent) {
+		if !strings.HasPrefix(text, indent) {
 			break
 		}
 		text = text[len(indent):]


### PR DESCRIPTION
``` diff
-       if !strings.HasPrefix(line, indent) {
+       if !strings.HasPrefix(text, indent) {
```

あと、diagnostic は indent が残ってるほうが後で表示したときに見栄えが良いので、indent を残したものも保持するようにしてみた。
