### PR TITLE
support noindented subtests

### DIFF
--- a/tap.go
+++ b/tap.go
@@ -162,7 +162,7 @@ func (p *Parser) next(indent string) (*Testline, error) {
 		}
 
 		// subtest
-		if strings.HasPrefix(line, "    # Subtest:") {
+		if strings.HasPrefix(line, "    # Subtest:") || strings.HasPrefix(line, "# Subtest:") {
 			t, err = p.parseSubTestline(indent)
 			break
 		}
@@ -281,7 +281,7 @@ func (p *Parser) parseTestLine(ok bool, line string, indent string) (*Testline, 
 		if p.suite.Version == 13 && strings.TrimSpace(text) == "---" {
 			yaml = p.parseYAML()
 		}
-		if len(text) == 1 || text[0] != '#' {
+		if len(text) == 1 || text[0] != '#' || strings.HasPrefix(text, "# Subtest:") {
 			break
 		}
 		diagnostics = append(diagnostics, strings.TrimSpace(text[1:])+"\n")

--- a/tap_test.go
+++ b/tap_test.go
@@ -199,6 +199,93 @@ ok 3 - foobar
 	}
 }
 
+func TestNoindentedSubtests(t *testing.T) {
+	r := strings.NewReader(`ok 1 - foo
+# Subtest: bar
+    ok 1 - subtest1
+    ok 2 - subtest2 # TODO not implemented yet
+    # note message for subtest2
+    ok 3 - subtest3
+    1..3
+ok 2 - bar
+ok 3 - foobar
+1..3
+`)
+	p, err := NewParser(r)
+	if err != nil {
+		panic(err)
+	}
+
+	suite, err := p.Suite()
+	if err != nil {
+		panic(err)
+	}
+
+	if len(suite.Tests) != 3 {
+		t.Errorf("want 3\ngot %d", len(suite.Tests))
+	}
+	if suite.Tests[0].SubTests != nil {
+		t.Errorf("want no subtests\ngot %v", suite.Tests[0].SubTests)
+	}
+	if len(suite.Tests[1].SubTests) != 3 {
+		t.Errorf("want 3\ngot %d", len(suite.Tests[0].SubTests))
+	}
+	if got, want := suite.Tests[1].SubTests[0].String(), "ok 1 - subtest1"; got != want {
+		t.Errorf("want %s\ngot %s", want, got)
+	}
+	if got, want := suite.Tests[1].SubTests[1].String(), "ok 2 - subtest2 # TODO not implemented yet"; got != want {
+		t.Errorf("want %s\ngot %s", want, got)
+	}
+	if got, want := suite.Tests[1].SubTests[2].String(), "ok 3 - subtest3"; got != want {
+		t.Errorf("want %s\ngot %s", want, got)
+	}
+	if suite.Tests[2].SubTests != nil {
+		t.Errorf("want no subtests\ngot %v", suite.Tests[2].SubTests)
+	}
+}
+
+func TestNoindentedSubsubtests(t *testing.T) {
+	r := strings.NewReader(`ok 1 - foo
+# Subtest: bar
+    # Subtest: subtest1
+        ok 1 - subsubtest1
+        ok 2 - subsubtest2 # TODO not implemented yet
+        # note message for subsubtest2
+        ok 3 - subsubtest3
+        1..3
+    ok 1 - subtest1
+    1..1
+ok 2 - bar
+ok 3 - foobar
+1..3
+`)
+	p, err := NewParser(r)
+	if err != nil {
+		panic(err)
+	}
+
+	suite, err := p.Suite()
+	if err != nil {
+		panic(err)
+	}
+
+	if len(suite.Tests) != 3 {
+		t.Errorf("want 3\ngot %d", len(suite.Tests))
+	}
+	if suite.Tests[0].SubTests != nil {
+		t.Errorf("want no subtests\ngot %v", suite.Tests[0].SubTests)
+	}
+	if len(suite.Tests[1].SubTests) != 1 {
+		t.Errorf("want 1\ngot %d", len(suite.Tests[0].SubTests))
+	}
+	if got, want := suite.Tests[1].SubTests[0].String(), "ok 1 - subtest1"; got != want {
+		t.Errorf("want %s\ngot %s", want, got)
+	}
+	if len(suite.Tests[1].SubTests[0].SubTests) != 3 {
+		t.Errorf("want 3\ngot %d", len(suite.Tests[1].SubTests[0].SubTests))
+	}
+}
+
 func TestInvalidLine(t *testing.T) {
 	r := strings.NewReader(`ok 1 - foo
     # Subtest: bar


### PR DESCRIPTION
Test2とそれ以前でどうも `# Subtest:` のインデントのしかたが違うようなのでPR作ってみました

```
 $ diff -u <(perl t/01.t) <(carton exec perl t/01.t)
--- /dev/fd/63	2017-10-08 09:47:05.000000000 +0900
+++ /dev/fd/62	2017-10-08 09:47:05.000000000 +0900
@@ -1,6 +1,6 @@
 ok 1 - foo
-# Subtest: bar
-    # Subtest: subtest1
+    # Subtest: bar
+        # Subtest: subtest1
         ok 1 - subsubtest1
         ok 2 - subsubtest2 # TODO not implemented yet
         # note message for subtests2
```

-----

### Test2 以前
```
$ carton exec -- perl -v | grep built
This is perl 5, version 26, subversion 1 (v5.26.1) built for darwin-2level
```
```
$ carton exec perl -MTest::More\ 999
Test::More version 999 required--this is only version 1.001014.
BEGIN failed--compilation aborted.
```
```
$ carton exec perl t/01.t
ok 1 - foo
    # Subtest: bar
        # Subtest: subtest1
        ok 1 - subsubtest1
        ok 2 - subsubtest2 # TODO not implemented yet
        # note message for subtests2
        ok 3 - subsubtest3
        1..3
    ok 1 - subtest1
    1..1
ok 2 - bar
ok 3 - foobar
1..3
```
### Test2
```
$ perl -v | grep built
This is perl 5, version 26, subversion 1 (v5.26.1) built for darwin-2level
```
```$ perl -MTest::More\ 999
Test::More version 999 required--this is only version 1.302073.
BEGIN failed--compilation aborted.
```
```
$ perl t/01.t
ok 1 - foo
# Subtest: bar
    # Subtest: subtest1
        ok 1 - subsubtest1
        ok 2 - subsubtest2 # TODO not implemented yet
        # note message for subtests2
        ok 3 - subsubtest3
        1..3
    ok 1 - subtest1
    1..1
ok 2 - bar
ok 3 - foobar
1..3
```