### PR TITLE
tap: keep whitespace in diagnostics

### DIFF
--- a/tap.go
+++ b/tap.go
@@ -284,7 +284,7 @@ func (p *Parser) parseTestLine(ok bool, line string, indent string) (*Testline, 
 		if len(text) <= 1 || text[0] != '#' || strings.HasPrefix(text, "# Subtest:") {
 			break
 		}
-		diagnostics = append(diagnostics, strings.TrimSpace(text[1:])+"\n")
+		diagnostics = append(diagnostics, text[1:]+"\n")
 	}
 
 	return &Testline{
@@ -401,7 +401,7 @@ func (t *Testline) dump(w io.Writer, indent string) error {
 		diagnostics := strings.Split(t.Diagnostic, "\n")
 		for _, l := range diagnostics[:len(diagnostics)-1] {
 			io.WriteString(w, indent)
-			io.WriteString(w, "# ")
+			io.WriteString(w, "#")
 			io.WriteString(w, l)
 			io.WriteString(w, "\n")
 		}


### PR DESCRIPTION
If the diagnostics contain text with indentation (like Go panic output),
the TrimSpace call will remove it and lead to unindented output.

Here's an example:

```
1..1
ok 1 MyTest
# output line 1:
#    output line 2
#    output line 3
```

This change ensures the indentation of `output line 2` and `output line 3` is preserved.