### PR TITLE
add Go 1.23 to the build matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,9 @@ jobs:
       fail-fast: false
       matrix:
         go:
+          - "stable"
+          - "1.23"
+          - "1.22"
           - "1.21"
           - "1.20"
           - "1.19"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded testing coverage by incorporating additional Go versions ("stable," "1.23," and "1.22") into the CI/CD pipeline.
  
- **Bug Fixes**
	- Improved reliability of the codebase across different Go environments through enhanced testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->